### PR TITLE
Use BOOST_CONCEPT_ASSERT instead of deprecated function_requires()

### DIFF
--- a/include/boost/property_map/parallel/parallel_property_maps.hpp
+++ b/include/boost/property_map/parallel/parallel_property_maps.hpp
@@ -20,7 +20,6 @@
 #include <boost/static_assert.hpp>
 #include <cstddef>
 #include <boost/detail/iterator.hpp>
-#include <boost/concept_check.hpp>
 #include <boost/concept_archetype.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/or.hpp>

--- a/include/boost/property_map/property_map.hpp
+++ b/include/boost/property_map/property_map.hpp
@@ -16,6 +16,7 @@
 #include <boost/static_assert.hpp>
 #include <cstddef>
 #include <boost/detail/iterator.hpp>
+#include <boost/concept/assert.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/concept_archetype.hpp>
 #include <boost/mpl/assert.hpp>
@@ -143,7 +144,7 @@ namespace boost {
     typedef typename property_traits<PMap>::category Category;
     typedef boost::readable_property_map_tag ReadableTag;
     void constraints() {
-      function_requires< ConvertibleConcept<Category, ReadableTag> >();
+      BOOST_CONCEPT_ASSERT((ConvertibleConcept<Category, ReadableTag>));
 
       val = get(pmap, k);
     }
@@ -175,7 +176,7 @@ namespace boost {
     typedef typename property_traits<PMap>::category Category;
     typedef boost::writable_property_map_tag WritableTag;
     void constraints() {
-      function_requires< ConvertibleConcept<Category, WritableTag> >();
+      BOOST_CONCEPT_ASSERT((ConvertibleConcept<Category, WritableTag>));
       put(pmap, k, val);
     }
     PMap pmap;
@@ -201,9 +202,9 @@ namespace boost {
     typedef typename property_traits<PMap>::category Category;
     typedef boost::read_write_property_map_tag ReadWriteTag;
     void constraints() {
-      function_requires< ReadablePropertyMapConcept<PMap, Key> >();
-      function_requires< WritablePropertyMapConcept<PMap, Key> >();
-      function_requires< ConvertibleConcept<Category, ReadWriteTag> >();
+      BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<PMap, Key>));
+      BOOST_CONCEPT_ASSERT((WritablePropertyMapConcept<PMap, Key>));
+      BOOST_CONCEPT_ASSERT((ConvertibleConcept<Category, ReadWriteTag>));
     }
   };
   template <typename KeyArchetype, typename ValueArchetype>
@@ -226,8 +227,8 @@ namespace boost {
     typedef typename property_traits<PMap>::reference reference;
 
     void constraints() {
-      function_requires< ReadablePropertyMapConcept<PMap, Key> >();
-      function_requires< ConvertibleConcept<Category, LvalueTag> >();
+      BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<PMap, Key>));
+      BOOST_CONCEPT_ASSERT((ConvertibleConcept<Category, LvalueTag>));
 
       typedef typename property_traits<PMap>::value_type value_type;
       BOOST_MPL_ASSERT((boost::mpl::or_<
@@ -259,10 +260,10 @@ namespace boost {
     typedef typename property_traits<PMap>::category Category;
     typedef boost::lvalue_property_map_tag LvalueTag;
     typedef typename property_traits<PMap>::reference reference;
-    void constraints() { 
-      boost::function_requires< ReadWritePropertyMapConcept<PMap, Key> >();
-      boost::function_requires<ConvertibleConcept<Category, LvalueTag> >();
-      
+    void constraints() {
+      BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<PMap, Key>));
+      BOOST_CONCEPT_ASSERT((ConvertibleConcept<Category, LvalueTag>));
+
       typedef typename property_traits<PMap>::value_type value_type;
       BOOST_MPL_ASSERT((boost::is_same<value_type&, reference>));
 
@@ -349,7 +350,7 @@ namespace boost {
     typename std::iterator_traits<RAIter>::value_type,
     typename std::iterator_traits<RAIter>::reference>
   make_iterator_property_map(RAIter iter, ID id) {
-    function_requires< RandomAccessIteratorConcept<RAIter> >();
+    BOOST_CONCEPT_ASSERT((RandomAccessIteratorConcept<RAIter>));
     typedef iterator_property_map<
       RAIter, ID,
       typename std::iterator_traits<RAIter>::value_type,
@@ -360,7 +361,7 @@ namespace boost {
   template <class RAIter, class Value, class ID>
   inline iterator_property_map<RAIter, ID, Value, Value&>
   make_iterator_property_map(RAIter iter, ID id, Value) {
-    function_requires< RandomAccessIteratorConcept<RAIter> >();
+    BOOST_CONCEPT_ASSERT((RandomAccessIteratorConcept<RAIter>));
     typedef iterator_property_map<RAIter, ID, Value, Value&> PMap;
     return PMap(iter, id);
   }
@@ -408,7 +409,7 @@ namespace boost {
     typename boost::detail::iterator_traits<RAIter>::value_type,
     typename boost::detail::iterator_traits<RAIter>::reference>
   make_safe_iterator_property_map(RAIter iter, std::size_t n, ID id) {
-    function_requires< RandomAccessIteratorConcept<RAIter> >();
+    BOOST_CONCEPT_ASSERT((RandomAccessIteratorConcept<RAIter>));
     typedef safe_iterator_property_map<
       RAIter, ID,
       typename boost::detail::iterator_traits<RAIter>::value_type,
@@ -418,7 +419,7 @@ namespace boost {
   template <class RAIter, class Value, class ID>
   inline safe_iterator_property_map<RAIter, ID, Value, Value&>
   make_safe_iterator_property_map(RAIter iter, std::size_t n, ID id, Value) {
-    function_requires< RandomAccessIteratorConcept<RAIter> >();
+    BOOST_CONCEPT_ASSERT((RandomAccessIteratorConcept<RAIter>));
     typedef safe_iterator_property_map<RAIter, ID, Value, Value&> PMap;
     return PMap(iter, n, id);
   }

--- a/test/compose_property_map_test.cpp
+++ b/test/compose_property_map_test.cpp
@@ -20,7 +20,7 @@ void concept_checks()
         typedef readable_property_map_archetype<Key, Key> GPMap;
         typedef readable_property_map_archetype<Key, Value> FPMap;
         typedef compose_property_map<FPMap, GPMap> CPM;
-        function_requires<ReadablePropertyMapConcept<CPM, Key> >();
+        BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<CPM, Key>));
     }
     {
         typedef null_archetype<> Key;
@@ -28,7 +28,7 @@ void concept_checks()
         typedef readable_property_map_archetype<Key, Key> GPMap;
         typedef writable_property_map_archetype<Key, Value> FPMap;
         typedef compose_property_map<FPMap, GPMap> CPM;
-        function_requires<WritablePropertyMapConcept<CPM, Key> >();
+        BOOST_CONCEPT_ASSERT((WritablePropertyMapConcept<CPM, Key>));
     }
     {
         typedef null_archetype<> Key;
@@ -36,7 +36,7 @@ void concept_checks()
         typedef readable_property_map_archetype<Key, Key> GPMap;
         typedef read_write_property_map_archetype<Key, Value> FPMap;
         typedef compose_property_map<FPMap, GPMap> CPM;
-        function_requires<ReadWritePropertyMapConcept<CPM, Key> >();
+        BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<CPM, Key>));
     }
     {
         typedef null_archetype<> Key;
@@ -44,7 +44,7 @@ void concept_checks()
         typedef readable_property_map_archetype<Key, Key> GPMap;
         typedef lvalue_property_map_archetype<Key, Value> FPMap;
         typedef compose_property_map<FPMap, GPMap> CPM;
-        function_requires<LvaluePropertyMapConcept<CPM, Key> >();
+        BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<CPM, Key>));
     }
     {
         typedef null_archetype<> Key;
@@ -52,7 +52,7 @@ void concept_checks()
         typedef readable_property_map_archetype<Key, Key> GPMap;
         typedef mutable_lvalue_property_map_archetype<Key, Value> FPMap;
         typedef compose_property_map<FPMap, GPMap> CPM;
-        function_requires<Mutable_LvaluePropertyMapConcept<CPM, Key> >();
+        BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<CPM, Key>));
     }
 }
 

--- a/test/function_property_map_test.cpp
+++ b/test/function_property_map_test.cpp
@@ -11,7 +11,7 @@
 //
 
 #include <boost/property_map/function_property_map.hpp>
-#include <boost/concept_check.hpp>
+#include <boost/concept/assert.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/test/minimal.hpp>
 #include <boost/static_assert.hpp>
@@ -32,14 +32,14 @@ struct return_fixed_ref {
 
 int test_main(int, char**) {
   using namespace boost;
-  function_requires<ReadablePropertyMapConcept<function_property_map<add1<int>, int>, int> >();
-  function_requires<ReadablePropertyMapConcept<function_property_map<add1<int>, int, double>, int> >();
-  function_requires<ReadablePropertyMapConcept<function_property_map<add1_val<int>, int>, int> >();
-  function_requires<ReadablePropertyMapConcept<function_property_map<add1_val<int>, int, double>, int> >();
-  function_requires<ReadablePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int> >();
-  function_requires<WritablePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int> >();
-  function_requires<ReadWritePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int> >();
-  function_requires<LvaluePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int> >();
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<function_property_map<add1<int>, int>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<function_property_map<add1<int>, int, double>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<function_property_map<add1_val<int>, int>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<function_property_map<add1_val<int>, int, double>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int>));
+  BOOST_CONCEPT_ASSERT((WritablePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int>));
+  BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int>));
+  BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<function_property_map<return_fixed_ref<int>, int>, int>));
 
   BOOST_STATIC_ASSERT((boost::is_same<boost::property_traits<function_property_map<add1<int>, int> >::category, boost::readable_property_map_tag>::value));
   BOOST_STATIC_ASSERT((boost::is_same<boost::property_traits<function_property_map<add1_val<int>, int> >::category, boost::readable_property_map_tag>::value));

--- a/test/property_map_cc.cpp
+++ b/test/property_map_cc.cpp
@@ -20,41 +20,41 @@ main()
     typedef null_archetype<> Key;
     typedef assignable_archetype<copy_constructible_archetype<> > Value;
     typedef readable_property_map_archetype<Key, Value> PMap;
-    function_requires<ReadablePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<PMap, Key>));
   }
   {
     typedef null_archetype<> Key;
     typedef assignable_archetype<copy_constructible_archetype<> > Value;
     typedef writable_property_map_archetype<Key, Value> PMap;
-    function_requires<WritablePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((WritablePropertyMapConcept<PMap, Key>));
   }
   {
     typedef null_archetype<> Key;
     typedef assignable_archetype<copy_constructible_archetype<> > Value;
     typedef read_write_property_map_archetype<Key, Value> PMap;
-    function_requires<ReadWritePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<PMap, Key>));
   }
   {
     typedef null_archetype<> Key;
     typedef assignable_archetype<copy_constructible_archetype<> > Value;
     typedef lvalue_property_map_archetype<Key, Value> PMap;
-    function_requires<LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef null_archetype<> Key;
     typedef assignable_archetype<copy_constructible_archetype<> > Value;
     typedef mutable_lvalue_property_map_archetype<Key, Value> PMap;
-    function_requires<Mutable_LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef std::ptrdiff_t Key;
     typedef int* PMap;
-    function_requires<Mutable_LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef std::ptrdiff_t Key;
     typedef const int* PMap;
-    function_requires<LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef sgi_assignable_archetype<> Key; // ?
@@ -66,7 +66,7 @@ main()
       , Value, const Value&
 #endif
       > PMap;
-    function_requires<LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef sgi_assignable_archetype<> Key;
@@ -78,7 +78,7 @@ main()
       , Value, Value&
 #endif
       > PMap;
-    function_requires<Mutable_LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef sgi_assignable_archetype< less_than_comparable_archetype<> > Key;
@@ -86,7 +86,7 @@ main()
       Value;
     typedef std::map<Key, Value> Container;
     typedef associative_property_map<Container> PMap;
-    function_requires<Mutable_LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef sgi_assignable_archetype< less_than_comparable_archetype<> > Key;
@@ -94,22 +94,22 @@ main()
       Value;
     typedef std::map<Key, Value> Container;
     typedef const_associative_property_map<Container> PMap;
-    function_requires<LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<PMap, Key>));
   }
   {
     typedef identity_property_map PMap;
-    function_requires<ReadablePropertyMapConcept<PMap, int> >();
+    BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<PMap, int>));
   }
   {
     typedef dummy_property_map PMap;
-    function_requires<ReadWritePropertyMapConcept<PMap, int> >();
+    BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<PMap, int>));
   }
   {
     typedef sgi_assignable_archetype<> Key; // ?
     typedef sgi_assignable_archetype<> Value;
     typedef readable_property_map_archetype<Key, std::ptrdiff_t> IndexMap;
     typedef shared_array_property_map<Value, IndexMap> PMap;
-    function_requires<Mutable_LvaluePropertyMapConcept<PMap, Key> >();
+    BOOST_CONCEPT_ASSERT((Mutable_LvaluePropertyMapConcept<PMap, Key>));
   }
   return 0;
 }

--- a/test/transform_value_property_map_test.cpp
+++ b/test/transform_value_property_map_test.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/property_map/function_property_map.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
-#include <boost/concept_check.hpp>
+#include <boost/concept/assert.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/test/minimal.hpp>
 #include <boost/static_assert.hpp>
@@ -38,14 +38,14 @@ int test_main(int, char**) {
   using namespace boost;
   typedef function_property_map<times2, int> PM;
   PM orig_pm(times2(0));
-  function_requires<ReadablePropertyMapConcept<transform_value_property_map<add1<int>, PM>, int> >();
-  function_requires<ReadablePropertyMapConcept<transform_value_property_map<add1<int>, PM, double>, int> >();
-  function_requires<ReadablePropertyMapConcept<transform_value_property_map<add1_val<int>, PM>, int> >();
-  function_requires<ReadablePropertyMapConcept<transform_value_property_map<add1_val<int>, PM, double>, int> >();
-  function_requires<ReadablePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int> >();
-  function_requires<WritablePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int> >();
-  function_requires<ReadWritePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int> >();
-  function_requires<LvaluePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int> >();
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<transform_value_property_map<add1<int>, PM>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<transform_value_property_map<add1<int>, PM, double>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<transform_value_property_map<add1_val<int>, PM>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<transform_value_property_map<add1_val<int>, PM, double>, int>));
+  BOOST_CONCEPT_ASSERT((ReadablePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int>));
+  BOOST_CONCEPT_ASSERT((WritablePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int>));
+  BOOST_CONCEPT_ASSERT((ReadWritePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int>));
+  BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<transform_value_property_map<return_fixed_ref<int>, PM>, int>));
 
   BOOST_STATIC_ASSERT((boost::is_same<boost::property_traits<transform_value_property_map<add1<int>, PM> >::category, boost::readable_property_map_tag>::value));
   BOOST_STATIC_ASSERT((boost::is_same<boost::property_traits<transform_value_property_map<add1_val<int>, PM> >::category, boost::readable_property_map_tag>::value));


### PR DESCRIPTION
Currently, `function_requires` is a wrapper around `BOOST_CONCEPT_ASSERT` and is marked for deprecation [by the docs](http://www.boost.org/doc/libs/1_61_0/libs/concept_check/reference.htm#deprecated-functions). This PR substitutes all calls to `function_requires` with calls to `BOOST_CONCEPT_ASSERT` in both code and tests.

Also remove `#include <boost/concept_check.hpp>` from all files (including `parallel_property_maps.hpp`) and leave it only in `property_map.hpp`

This is my first PR to boost, I am just trying to get the hang of it all. Feel free to reject and/or point out problems.
