### PR TITLE
Remove uses of deprecated header boost/detail/iterator.hpp

### DIFF
--- a/include/boost/property_map/parallel/parallel_property_maps.hpp
+++ b/include/boost/property_map/parallel/parallel_property_maps.hpp
@@ -19,7 +19,6 @@
 #include <boost/config.hpp>
 #include <boost/static_assert.hpp>
 #include <cstddef>
-#include <boost/detail/iterator.hpp>
 #include <boost/concept_archetype.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/or.hpp>
@@ -222,7 +221,7 @@ public:
                              const index_map_type& id)
     : inherited(id.process_group(), id.global(), 
                 local_iterator_map(cc, n, id.base())) { }
-};                                            
+};
 
 }
 

--- a/include/boost/property_map/property_map.hpp
+++ b/include/boost/property_map/property_map.hpp
@@ -15,7 +15,7 @@
 #include <boost/config.hpp>
 #include <boost/static_assert.hpp>
 #include <cstddef>
-#include <boost/detail/iterator.hpp>
+#include <iterator>
 #include <boost/concept/assert.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/concept_archetype.hpp>
@@ -407,14 +407,14 @@ namespace boost {
   template <class RAIter, class ID>
   inline safe_iterator_property_map<
     RAIter, ID,
-    typename boost::detail::iterator_traits<RAIter>::value_type,
-    typename boost::detail::iterator_traits<RAIter>::reference>
+    typename std::iterator_traits<RAIter>::value_type,
+    typename std::iterator_traits<RAIter>::reference>
   make_safe_iterator_property_map(RAIter iter, std::size_t n, ID id) {
     BOOST_CONCEPT_ASSERT((RandomAccessIteratorConcept<RAIter>));
     typedef safe_iterator_property_map<
       RAIter, ID,
-      typename boost::detail::iterator_traits<RAIter>::value_type,
-      typename boost::detail::iterator_traits<RAIter>::reference> PA;
+      typename std::iterator_traits<RAIter>::value_type,
+      typename std::iterator_traits<RAIter>::reference> PA;
     return PA(iter, n, id);
   }
   template <class RAIter, class Value, class ID>

--- a/include/boost/property_map/vector_property_map.hpp
+++ b/include/boost/property_map/vector_property_map.hpp
@@ -11,7 +11,8 @@
 #define BOOST_PROPERTY_MAP_VECTOR_PROPERTY_MAP_HPP
 
 #include <boost/property_map/property_map.hpp>
-#include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <iterator>
 #include <vector>
 
 namespace boost {
@@ -28,7 +29,7 @@ namespace boost {
         typedef typename std::iterator_traits< 
             typename std::vector<T>::iterator >::reference reference;
         typedef boost::lvalue_property_map_tag category;
-        
+
         vector_property_map(const IndexMap& index = IndexMap())
         : store(new std::vector<T>()), index(index)
         {}
@@ -57,15 +58,15 @@ namespace boost {
         {
             return store->end();
         }
-                 
+
         IndexMap&       get_index_map()       { return index; }
         const IndexMap& get_index_map() const { return index; }
-          
+
     public:
         // Copy ctor absent, default semantics is OK.
         // Assignment operator absent, default semantics is OK.
         // CONSIDER: not sure that assignment to 'index' is correct.
-        
+
         reference operator[](const key_type& v) const {
             typename property_traits<IndexMap>::value_type i = get(index, v);
             if (static_cast<unsigned>(i) >= store->size()) {
@@ -80,10 +81,10 @@ namespace boost {
         // store pointer to data, because if copy of property map resizes
         // the vector, the pointer to data will be invalidated. 
         // I wonder if class 'pmap_ref' is simply needed.
-        shared_ptr< std::vector<T> > store;        
+        shared_ptr< std::vector<T> > store;
         IndexMap index;
     };
-    
+
     template<typename T, typename IndexMap>
     vector_property_map<T, IndexMap>
     make_vector_property_map(IndexMap index)


### PR DESCRIPTION
This header was deprecated in favor of `<iterator>`. It generates compiler warnings and will be removed in a future release.