### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/property_map/dynamic_property_map.hpp
+++ b/include/boost/property_map/dynamic_property_map.hpp
@@ -24,13 +24,15 @@
 #include <boost/any.hpp>
 #include <boost/function/function3.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <typeinfo>
 #include <boost/mpl/bool.hpp>
-#include <stdexcept>
-#include <sstream>
-#include <map>
 #include <boost/type.hpp>
 #include <boost/smart_ptr.hpp>
+#include <exception>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <typeinfo>
 
 namespace boost {
 
@@ -70,17 +72,17 @@ public:
 //////////////////////////////////////////////////////////////////////
 
 struct dynamic_property_exception : public std::exception {
-  virtual ~dynamic_property_exception() throw() {}
-  virtual const char* what() const throw() = 0;
+  ~dynamic_property_exception() throw() BOOST_OVERRIDE {}
+  const char* what() const throw() BOOST_OVERRIDE = 0;
 };
 
 struct property_not_found : public dynamic_property_exception {
   std::string property;
   mutable std::string statement;
   property_not_found(const std::string& property) : property(property) {}
-  virtual ~property_not_found() throw() {}
+  ~property_not_found() throw() BOOST_OVERRIDE {}
 
-  const char* what() const throw() {
+  const char* what() const throw() BOOST_OVERRIDE {
     if(statement.empty())
       statement =
         std::string("Property not found: ") + property + ".";
@@ -93,9 +95,9 @@ struct dynamic_get_failure : public dynamic_property_exception {
   std::string property;
   mutable std::string statement;
   dynamic_get_failure(const std::string& property) : property(property) {}
-  virtual ~dynamic_get_failure() throw() {}
+  ~dynamic_get_failure() throw() BOOST_OVERRIDE {}
 
-  const char* what() const throw() {
+  const char* what() const throw() BOOST_OVERRIDE {
     if(statement.empty())
       statement =
         std::string(
@@ -107,9 +109,9 @@ struct dynamic_get_failure : public dynamic_property_exception {
 };
 
 struct dynamic_const_put_error  : public dynamic_property_exception {
-  virtual ~dynamic_const_put_error() throw() {}
+  ~dynamic_const_put_error() throw() BOOST_OVERRIDE {}
 
-  const char* what() const throw() {
+  const char* what() const throw() BOOST_OVERRIDE {
     return "Attempt to put a value into a const property map: ";
   }
 };
@@ -169,27 +171,27 @@ public:
   explicit dynamic_property_map_adaptor(const PropertyMap& property_map_)
     : property_map_(property_map_) { }
 
-  virtual boost::any get(const any& key_)
+  boost::any get(const any& key_) BOOST_OVERRIDE
   {
     return get_wrapper_xxx(property_map_, any_cast<typename boost::property_traits<PropertyMap>::key_type>(key_));
   }
 
-  virtual std::string get_string(const any& key_)
+  std::string get_string(const any& key_) BOOST_OVERRIDE
   {
     std::ostringstream out;
     out << get_wrapper_xxx(property_map_, any_cast<typename boost::property_traits<PropertyMap>::key_type>(key_));
     return out.str();
   }
 
-  virtual void put(const any& in_key, const any& in_value)
+  void put(const any& in_key, const any& in_value) BOOST_OVERRIDE
   {
     do_put(in_key, in_value,
            mpl::bool_<(is_convertible<category*,
                                       writable_property_map_tag*>::value)>());
   }
 
-  virtual const std::type_info& key()   const { return typeid(key_type); }
-  virtual const std::type_info& value() const { return typeid(value_type); }
+  const std::type_info& key()   const BOOST_OVERRIDE { return typeid(key_type); }
+  const std::type_info& value() const BOOST_OVERRIDE { return typeid(value_type); }
 
   PropertyMap&       base()       { return property_map_; }
   const PropertyMap& base() const { return property_map_; }


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Alphabetical order of STL headers.