### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(boost_property_map
     Boost::lexical_cast
     Boost::mpl
     Boost::smart_ptr
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
     Boost::utility

--- a/build.jam
+++ b/build.jam
@@ -16,7 +16,6 @@ constant boost_dependencies :
     /boost/lexical_cast//boost_lexical_cast
     /boost/mpl//boost_mpl
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_index//boost_type_index
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.