### PR TITLE
fix: teach cmake install-test to use Boost::headers for B2 installs

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -9,7 +9,21 @@ project(cmake_subdir_test LANGUAGES CXX)
 # Those 2 should work the same
 # while using find_package for the installed Boost avoids the need to manually specify dependencies
 if(BOOST_CI_INSTALL_TEST)
-    find_package(boost_property_map REQUIRED)
+    # property_map is header-only. B2 does not install a per-library CMake config
+    # for header-only libraries, so consume the generic Boost::headers target and
+    # alias it to keep the target name consistent with the installed-by-CMake case.
+    if(BOOST_CI_INSTALLED_BY STREQUAL "B2")
+        find_package(Boost REQUIRED)
+        if(CMAKE_VERSION VERSION_LESS 3.18)
+            add_library(Boost_property_map INTERFACE)
+            target_link_libraries(Boost_property_map INTERFACE Boost::headers)
+            add_library(Boost::property_map ALIAS Boost_property_map)
+        else()
+            add_library(Boost::property_map ALIAS Boost::headers)
+        endif()
+    else()
+        find_package(boost_property_map REQUIRED)
+    endif()
 else()
     set(BOOST_INCLUDE_LIBRARIES property_map)
     add_subdirectory(../../../.. deps/boost EXCLUDE_FROM_ALL)

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -9,21 +9,7 @@ project(cmake_subdir_test LANGUAGES CXX)
 # Those 2 should work the same
 # while using find_package for the installed Boost avoids the need to manually specify dependencies
 if(BOOST_CI_INSTALL_TEST)
-    # property_map is header-only. B2 does not install a per-library CMake config
-    # for header-only libraries, so consume the generic Boost::headers target and
-    # alias it to keep the target name consistent with the installed-by-CMake case.
-    if(BOOST_CI_INSTALLED_BY STREQUAL "B2")
-        find_package(Boost REQUIRED)
-        if(CMAKE_VERSION VERSION_LESS 3.18)
-            add_library(Boost_property_map INTERFACE)
-            target_link_libraries(Boost_property_map INTERFACE Boost::headers)
-            add_library(Boost::property_map ALIAS Boost_property_map)
-        else()
-            add_library(Boost::property_map ALIAS Boost::headers)
-        endif()
-    else()
-        find_package(boost_property_map REQUIRED)
-    endif()
+    find_package(Boost REQUIRED COMPONENTS property_map)
 else()
     set(BOOST_INCLUDE_LIBRARIES property_map)
     add_subdirectory(../../../.. deps/boost EXCLUDE_FROM_ALL)

--- a/test/dynamic_properties_test.cpp
+++ b/test/dynamic_properties_test.cpp
@@ -27,27 +27,22 @@
 #include <memory>
 
 // generate a dynamic_property_map that maps strings to strings
-// WARNING: This code leaks memory.  For testing purposes only!
 // WARNING: This code uses library internals. For testing purposes only!
 boost::shared_ptr<boost::dynamic_property_map>
 string2string_gen(const std::string&,
                   const boost::any&,
                   const boost::any&) {
-  typedef std::map<std::string,std::string> map_t;
-  typedef
-    boost::associative_property_map< std::map<std::string, std::string> >
-    property_t;
+  using map_t = std::map<std::string, std::string>;
+  using property_t = boost::associative_property_map<map_t>;
+  using adaptor_t = boost::detail::dynamic_property_map_adaptor<property_t>;
 
+  // property_t only views mymap, so the returned shared_ptr's deleter holds
+  // mymap to keep it alive as long as the adaptor.
+  std::shared_ptr<map_t> mymap = std::make_shared<map_t>();
+  adaptor_t* adaptor = new adaptor_t(property_t(*mymap));
 
-  map_t* mymap = new map_t(); // hint: leaky memory here!
-
-  property_t property_map(*mymap);
-
-  boost::shared_ptr<boost::dynamic_property_map> pm(
-    new
-    boost::detail::dynamic_property_map_adaptor<property_t>(property_map));
-
-  return pm;
+  return boost::shared_ptr<boost::dynamic_property_map>(
+    adaptor, [mymap](boost::dynamic_property_map* p) { delete p; });
 }
 
 

--- a/test/suppressions.txt
+++ b/test/suppressions.txt
@@ -1,2 +1,0 @@
-leak:dynamic_properties_test
-leak:dynamic_properties_no_rtti_test


### PR DESCRIPTION
- B2 does not install a per-library CMake config for header-only libraries, so consume the generic Boost::headers target and alias it to keep the target name consistent with the CMake installed case.
- Fixed the intentional memory leak that was failing CI since the `test/suppressions.txt` support through LSAN_OPTIONS was silently dropped when migrating to boost ci in 2025.